### PR TITLE
Update Manifest2Annotation_EPIC_v2.R

### DIFF
--- a/Manifest2Annotation_EPIC_v2.R
+++ b/Manifest2Annotation_EPIC_v2.R
@@ -4,7 +4,7 @@ library("tidyverse")
 library("glue")
 library("magrittr")
 library("stringr")
-
+library(qdapRegex)
 
 manifest_dir <- "./MethylationEPIC v2.0 Files/EPIC-8v2-0_A1.csv"
 assay_line <- which(substr(readLines(manifest_dir),1,7) == "[Assay]")


### PR DESCRIPTION
添加了library(qdapRegex)，pop <- ex_between(EPICv2_Mask$maskUniq, "_SNP_", "_")里面的ex_between是这个包里的函数，不导入包的话报错